### PR TITLE
feat(curator): Get disk size input for use in ES indices deletion

### DIFF
--- a/env-prep
+++ b/env-prep
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -n "${SDEBUG:-}" ] ; then
+  set -x
+fi
+
+# Override default logging namespace
+# Try 'openshift-logging' or 'logging'
+if [ -f ".logging-ns" ] ; then
+  LOGGING_NS=$(cat .logging-ns)
+fi
+
+export LOGGING_NS=${LOGGING_NS:-openshift-logging}
+if [ -z "${pod:-}" ] ; then
+  pod=$(oc -n $LOGGING_NS get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
+  if [ "$?" != "0" ] ; then
+    echo "Running 'oc -n $LOGGING_NS get pod -l component=elasticsearch' failed, possibly due to the" >&2
+    echo "namespace being wrong. Look into 'env-prep' file to see how to override that." >&2
+    echo "(If this is a V3 cluster, run 'git checkout release-3.x' before doing anything else.)" >&2
+  fi
+fi

--- a/es-used-disk
+++ b/es-used-disk
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+source env-prep
+
+COLLUMN=$1
+
+for p in $(oc -n ${LOGGING_NS} get pods -o jsonpath={.items[*].metadata.name} -l component=elasticsearch); do
+  oc -n ${LOGGING_NS} exec -c elasticsearch $p -- df -m | grep -E "persistent|Mounted" | awk '{ print $c }' c=$COLLUMN;
+done
+


### PR DESCRIPTION
- **Added es-used-disk & env-prep scripts:**
I wasn't sure if request for adding "column filter" into project _cluster-logging-tools/scripts/es-disk-usage_ would be good or bad idea.
- **Modified curator.py:**
Feel free to merge both functions _get_disk_total()_ and _get_disk_used()_. I temporarily split them so it was more easy to work with it for me.
At the line 101 is exit command! I didnt have time to look at what is preventing connection in _main()_ function below.